### PR TITLE
Update video reviewer field help text

### DIFF
--- a/pinaxcon/proposals/models.py
+++ b/pinaxcon/proposals/models.py
@@ -76,10 +76,12 @@ class ConferenceSpeaker(SpeakerBase):
     reviewer = models.EmailField(
         blank=True,
         null=True,
-        verbose_name=_("E-mail of video reviewer"),
-        help_text=_("Include the e-mail address of someone who can watch a "
-                    "video of your talk, shortly after the video is produced, "
-                    "to ensure quality."),
+        verbose_name=_("Email of video reviewer"),
+        help_text=_("Email address of someone, not yourself, that will "
+                    "<a href='https://github.com/CarlFK/veyepar/wiki/Reviewer'>"
+                    "review the video of your talk"
+                    "</a>"
+                    " to make sure it is ready to publish"),
         )
 
     code_of_conduct = models.BooleanField(


### PR DESCRIPTION
Updates the video reviewer field help text on the speaker profile form
with clearer language and a link to a page that further explains the
video reviewer.

Also updates the verbose name to be consistent with other
instances of the word "email" on the site.

Fixes #28