### PR TITLE
Remove http host from OpenGraph image URL

### DIFF
--- a/pinaxcon/templates/site_base.html
+++ b/pinaxcon/templates/site_base.html
@@ -16,7 +16,7 @@
       <meta property="og:title" content="{% block head_title %}{% endblock %} | {{ SITE_NAME }}">
       <meta property="twitter:title" content="{{ SITE_NAME }}">
       <meta property="og:site_name" content="{{ SITE_NAME }}">
-      <meta property="og:image" content="http://{{ request.META.HTTP_HOST }}{% static "images/pyohio-logo-square.png" %}">
+      <meta property="og:image" content="{% static "images/pyohio-logo-square.png" %}">
       <meta property="og:image:width" content="500">
       <meta property="og:image:height" content="500">
       <meta property="og:url" content="{{ request.build_absolute_uri }}">


### PR DESCRIPTION
Removed the http host from the start of the OpenGraph image URL meta tag
so that it will be correct in production. The static macro makes the
correct full URL in production but will not in development. Hopefully
this is an acceptable compromise.

Fixes (or attempts to) #30.