### PR TITLE
I#27 #23 fix teams interface

### DIFF
--- a/fixtures/base/teams.json
+++ b/fixtures/base/teams.json
@@ -24,15 +24,5 @@
     "permissions": [],
     "manager_permissions": []
   }
-},
-{
-  "model": "teams.membership",
-  "pk": 3,
-  "fields": {
-    "user": 3,
-    "team": 1,
-    "state": "member",
-    "message": ""
-  }
 }
 ]

--- a/fixtures/base/teams.json
+++ b/fixtures/base/teams.json
@@ -17,8 +17,8 @@
   "pk": 2,
   "fields": {
     "slug": "program-committee",
-    "name": "Program Comittee",
-    "description": "I am not a comittee!",
+    "name": "Program Committee",
+    "description": "I am not a committee!",
     "access": "invitation",
     "created": "2018-02-17T18:00:26.572Z",
     "permissions": [],

--- a/fixtures/base/teams.json
+++ b/fixtures/base/teams.json
@@ -1,0 +1,38 @@
+[
+{
+  "model": "teams.team",
+  "pk": 1,
+  "fields": {
+    "slug": "reviewers",
+    "name": "Reviewers",
+    "description": "Talk and Tutorial submission reviewers.",
+    "access": "open",
+    "created": "2018-02-17T00:49:21.546Z",
+    "permissions": [],
+    "manager_permissions": []
+  }
+},
+{
+  "model": "teams.team",
+  "pk": 2,
+  "fields": {
+    "slug": "program-committee",
+    "name": "Program Comittee",
+    "description": "I am not a comittee!",
+    "access": "invitation",
+    "created": "2018-02-17T18:00:26.572Z",
+    "permissions": [],
+    "manager_permissions": []
+  }
+},
+{
+  "model": "teams.membership",
+  "pk": 3,
+  "fields": {
+    "user": 3,
+    "team": 1,
+    "state": "member",
+    "message": ""
+  }
+}
+]

--- a/pinaxcon/templates/site_base.html
+++ b/pinaxcon/templates/site_base.html
@@ -42,6 +42,8 @@
                 <div class="col-md-9">
                     {% block body %}
                     {% endblock %}
+                    {% block body_outer %}
+                    {% endblock %}
                 </div>
                 <div class="col-md-3">
                     {% block sidebar %}


### PR DESCRIPTION
This should add the teams functionality from Symposion. It looks like all we needed was to include the correct block the teams app uses in site_base.html. We could also consider updating the teams app to use the regular body instead of "body_outer". I "think" either this change or updating the teams app should be safe and just a matter of preference, I didn't really see much using "body_outer" in either pinaxcon or symposion.

Teams should be fairly self-service. An "open" team will allow users to join / leave freely. An "invitation" team only seems to display for team members and admins. An invitation to join can be extended by an admin (probably also by the team manager, though I have not tried that yet).

I'm not sure exactly how permissions are working in staging / production so I did not add them to the fixtures. Giving the reviewers teams the review permissions is as simple as adding to the reviewers team in the admin interface after the permissions have been created. I don't think not having the perms by default will be a big issue as we probably don't want to reset the DB often anyways. Perhaps dev fixtures would be useful though.