### PR TITLE
replace the admin login form with the website Email based login

### DIFF
--- a/pinaxcon/urls.py
+++ b/pinaxcon/urls.py
@@ -82,9 +82,6 @@ original_patterns = [
     url(r"^jobs$", TemplateView.as_view(template_name="static_pages/jobs/job_board.html"), name="jobs"),
 
     # Django, Symposion, and Registrasion URLs
-
-    url(r"^admin/", include(admin.site.urls)),
-
     url(r"^login$", views.account_login, name="dashboard_login"),
     # Override the default account_login view with one that takes email addys
     url(r"^account/login/$", views.EmailLoginView.as_view(), name="account_login"),
@@ -92,6 +89,9 @@ original_patterns = [
     url(r"^account/", include("account.urls")),
 
     url(r"^dashboard/", symposion.views.dashboard, name="dashboard"),
+
+    url(r"^admin/login/", views.EmailLoginView.as_view(), name="admin_login"),
+    url(r"^admin/", include(admin.site.urls)),
 
     url(r"^speaker/", include("symposion.speakers.urls")),
     url(r"^proposals/", include("symposion.proposals.urls")),


### PR DESCRIPTION
#26 Taking the simple route of replacing the admin login form with the PyOhio Website Login Form. 

It looks a bit strange at first as it does not have the Django Admin Styling, but it does get the job done. After logging in you are forwarded to the Django admin page.