### PR TITLE
Update jQuery in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "bootstrap": "^3.3.6",
     "font-awesome": "^4.5.0",
-    "jquery": "^2.1.4"
+    "jquery": "^3.0.0"
   },
   "babel": {
     "presets": [


### PR DESCRIPTION
Fixes #13 

* The jQuery version sourced in each page is > 3.0.0 and is unaffected by this change
* Our Bootstrap version supports v3 and is therefore unaffected by this change
* Font Awesome doesn't rely on jQuery at all and is therefore unaffected by this change