### PR TITLE
Fix Sponsors section getting stuck in floats

### DIFF
--- a/pinaxcon/templatetags/pyohio_tags.py
+++ b/pinaxcon/templatetags/pyohio_tags.py
@@ -22,7 +22,7 @@ def user_bio(username):
 def make_bio_html(username):
     user = User.objects.get(username=username)
     speaker = ConferenceSpeaker.objects.get(user=user)
-    html = """<p><img src="{0}" alt="{1}" class="team-headshot">{2}</p>"""
+    html = """<p class="float-left"><img src="{0}" alt="{1}" class="team-headshot">{2}</p>"""
     if speaker.twitter_username:
         twitter_username = speaker.twitter_username.lstrip('@')
         html += """<p><a class="twitter-follow-button" data-show-count="false" href="https://twitter.com/{0}">@{0}</a>""".format(twitter_username)

--- a/static/js/site.js
+++ b/static/js/site.js
@@ -31,6 +31,11 @@ $(document).ready(function() {
     if(urlPath.match(/reviews\/.+\/notification/)) {
         handleResultNotificationElements();
     }
+
+    if(urlPath.match(/about\/team/)) {
+        // crappy float fix
+        $('.col-md-9').addClass('clearfix');
+    }
 });
 
 function handleHomeAlert() {

--- a/static/scss/custom.scss
+++ b/static/scss/custom.scss
@@ -347,14 +347,16 @@ body.about {
 
   .team-headshot {
     width: 150px;
-    float: left;
     margin-right: 1em;
     margin-top: 0.25em;
-    margin-bottom: 1em;
   }
 
   .bio-block {
       min-height: 1.5em;
+  }
+
+  .float-left {
+    float: left;
   }
 }
 


### PR DESCRIPTION
Found this while trying to figure out why my speaker profile pic was sideways:

On smaller screens that are _not_ necessarily phones, the way speaker pics were floated and not cleared caused the alignment to get screwy and the sponsors section creeped up in to the last bio.  You can see this if you emulate the page as something like a Nexus 4, or whatever Chrome thinks "iPad" is supposed to be nowadays.

This floats the container of the image (instead of the image itself), and slaps clearfix on the main content div for easy alignment fixes.  Also removes the bottom margin off the image to make the text line up to it a bit better.

Tested by:
* Using my short bio
* Making a really long bio
* Regular desktop view and some mobile emulations