### PR TITLE
Change link color to stand out better from the black text

### DIFF
--- a/static/scss/variables.scss
+++ b/static/scss/variables.scss
@@ -3,6 +3,8 @@
 $brand-primary: rgb(38, 59, 108);
 $background-filter: hsla(207, 60%, 85%, 1.0);
 $background-filter-transparent: change-color($background-filter, $alpha: 0.5);
+$link-color: rgb(0, 131, 143);
+$link-hover-color: darken($link-color, 10%);
 
 /* TEXT */
 $font-family-sans-serif:  "Nunito", Arial, sans-serif;


### PR DESCRIPTION
Since the color rebranding, links are really hard to discern from the text surrounding them.

I opted to change the color of the links to be different from the `$brand-primary` CSS variable, because a) the green stood out before and b) IMO underlines alone aren't enough here.  Links are now a pleasant teal.
e: said teal passes WCAG AAA.

Screenshots:
![large homepage links](https://user-images.githubusercontent.com/5710080/39903444-3e90296e-54a1-11e8-894c-f7bc7722b8b8.png)
![small footer links](https://user-images.githubusercontent.com/5710080/39903445-3ea297d4-54a1-11e8-9dc0-0ab43e8388b4.png)
