### PR TITLE
Cheap and easy homepage a11y fixes

### DIFF
--- a/pinaxcon/templates/override_bootstrap_theme_base.html
+++ b/pinaxcon/templates/override_bootstrap_theme_base.html
@@ -40,7 +40,7 @@ OTHER DEALINGS IN THE SOFTWARE.
                 <span class="hidden-accessible">Pages Menu</span>
               </span>
             </button>
-            {% block site_brand %}<a class="navbar-brand" href="{% url "home" %}"><img width="32" src="{% static "images/pyohio-white-sq-transparent-small.png" %}"/> {{ SITE_NAME }}</a>{% endblock %}
+            {% block site_brand %}<a class="navbar-brand" href="{% url "home" %}"><img width="32" src="{% static "images/pyohio-white-sq-transparent-small.png" %}" alt=""/> {{ SITE_NAME }}</a>{% endblock %}
           </div>
           <div class="collapse navbar-collapse navbar-responsive-collapse">
             {% block nav %}

--- a/pinaxcon/templates/static_pages/homepage.html
+++ b/pinaxcon/templates/static_pages/homepage.html
@@ -51,7 +51,7 @@
 
   <div class="jumbotron homepage-block white">
     <div class="container homepage-block-content">
-      <h1>Sponsors</h1>
+      <h2>Sponsors</h2>
 
       {% sponsor_levels as levels %}
 


### PR DESCRIPTION
* Adds empty alt to header nav logo
* Changes sponsors header from h1 to h2

Verified changes in WAVE and aXe