### PR TITLE
Fix word breaks for schedule table in portrait mode

### DIFF
--- a/static/scss/symposion-schedule.scss
+++ b/static/scss/symposion-schedule.scss
@@ -2,6 +2,7 @@ table.calendar {
   background-color: #fffff;
   table-layout: fixed;
   font-size: 12px;
+  word-break: break-word;
 
   tr {
     min-height: 36px;


### PR DESCRIPTION
It's still ugly but this way it doesn't spill over the neighboring columns in portrait mode now.